### PR TITLE
Move centrality measures in a separate file

### DIFF
--- a/rusty_ex/src/configs/centrality.rs
+++ b/rusty_ex/src/configs/centrality.rs
@@ -1,0 +1,164 @@
+use petgraph::graph::NodeIndex;
+
+use crate::types::FeaturesGraph;
+
+#[derive(Default)]
+pub struct Centrality {
+    pub measures: Measures,
+    pub feat_graph_indices: Vec<NodeIndex>,
+}
+
+#[derive(Default)]
+pub struct Measures {
+    pub katz: Option<Vec<f64>>,
+    pub closeness: Vec<Option<f64>>,
+    pub eigenvector: Option<Vec<f64>>,
+}
+
+impl Centrality {
+    pub fn new(feat_graph: &FeaturesGraph) -> Self {
+        let feat_graph_indices = feat_graph.graph.node_indices().collect::<Vec<NodeIndex>>();
+        let measures = Measures {
+            katz: Centrality::compute_katz(feat_graph),
+            closeness: Centrality::compute_closeness(feat_graph),
+            eigenvector: Centrality::compute_eigenvector(feat_graph),
+        };
+        Centrality {
+            measures,
+            feat_graph_indices,
+        }
+    }
+
+    fn compute_katz(feat_graph: &FeaturesGraph) -> Option<Vec<f64>> {
+        let katz: rustworkx_core::Result<Option<Vec<f64>>> =
+            rustworkx_core::centrality::katz_centrality(
+                &feat_graph.graph,
+                |e| Ok(e.weight().weight),
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+
+        match katz {
+            Ok(katz) => {
+                return katz;
+            }
+            Err(e) => {
+                // TODO: Probabily we should return handle this error gracefully
+                panic!("Error computing katz centrality: {:?}", e);
+            }
+        }
+    }
+
+    // The Option around the f64 is because the closeness centrality can fail
+    // if the graph is not connected (i.e. there is a node that is not reachable
+    // from all other nodes)
+    fn compute_closeness(feat_graph: &FeaturesGraph) -> Vec<Option<f64>> {
+        rustworkx_core::centrality::closeness_centrality(&feat_graph.graph, true)
+    }
+
+    fn compute_eigenvector(feat_graph: &FeaturesGraph) -> Option<Vec<f64>> {
+        let eigenvector: rustworkx_core::Result<Option<Vec<f64>>> =
+            rustworkx_core::centrality::eigenvector_centrality(
+                &feat_graph.graph,
+                |e| Ok(e.weight().weight),
+                None,
+                Some(1e-2),
+            );
+
+        match eigenvector {
+            Ok(eigenvector) => {
+                return eigenvector;
+            }
+            Err(e) => {
+                // TODO: Probabily we should return handle this error gracefully
+                panic!("Error computing eigenvector centrality: {:?}", e);
+            }
+        }
+    }
+
+    // NOTE: To avoid to keep a reference to the FeaturesGraph, we pass it as an argument
+    // to the pretty_print method instead of storing it in the struct. It means that the
+    // feature graph passed to the pretty_print method should be the same used to createù
+    // the Centrality struct.
+    pub fn pretty_print(&self, feat_graph: &FeaturesGraph) {
+        let katz_zip = match self.measures.katz.as_ref() {
+            Some(katz) => Ok(katz.iter().zip(self.feat_graph_indices.iter())),
+            None => Err("Katz centrality not computed"),
+        };
+        let closeness_zip = self
+            .measures
+            .closeness
+            .iter()
+            .zip(self.feat_graph_indices.iter());
+        let eigenvector_zip = match self.measures.eigenvector.as_ref() {
+            Some(eigenvector) => Ok(eigenvector.iter().zip(self.feat_graph_indices.iter())),
+            None => Err("Eigenvector centrality not computed"),
+        };
+
+        println!("Centrality measures:");
+        println!("Katz centrality:");
+        match katz_zip {
+            Ok(katz) => {
+                for (katz, node) in katz {
+                    let feature_node = feat_graph.graph.node_weight(*node).unwrap();
+                    println!(
+                        "Node: {:?}, Feature: ({:?}, {:?}), centrality: {:.4}",
+                        node.index(),
+                        feature_node.feature.0.name,
+                        feature_node.feature.0.not,
+                        katz
+                    );
+                }
+            }
+            Err(e) => {
+                println!("{}", e);
+            }
+        }
+
+        println!("Closeness centrality:");
+        for (closeness, node) in closeness_zip {
+            let feature_node = feat_graph.graph.node_weight(*node).unwrap();
+            match closeness {
+                Some(closeness) => {
+                    println!(
+                        "Node: {:?}, Feature: ({:?}, {:?}), centrality: {:.4}",
+                        node.index(),
+                        feature_node.feature.0.name,
+                        feature_node.feature.0.not,
+                        closeness
+                    );
+                }
+                None => {
+                    println!(
+                        "Node: {:?}, Feature: ({:?}, {:?}), centrality: Not connected",
+                        node.index(),
+                        feature_node.feature.0.name,
+                        feature_node.feature.0.not
+                    );
+                }
+            }
+        }
+
+        println!("Eigenvector centrality:");
+        match eigenvector_zip {
+            Ok(eigenvector) => {
+                for (eigenvector, node) in eigenvector {
+                    let feature_node = feat_graph.graph.node_weight(*node).unwrap();
+                    println!(
+                        "Node: {:?}, Feature: ({:?}, {:?}), centrality: {:.4}",
+                        node.index(),
+                        feature_node.feature.0.name,
+                        feature_node.feature.0.not,
+                        eigenvector
+                    );
+                }
+            }
+            Err(e) => {
+                println!("{}", e);
+            }
+        }
+    }
+}

--- a/rusty_ex/src/configs/mod.rs
+++ b/rusty_ex/src/configs/mod.rs
@@ -1,3 +1,4 @@
+pub mod centrality;
 pub mod config_generator;
 pub mod prop_formula;
 

--- a/rusty_ex/tests/test_config_generator.rs
+++ b/rusty_ex/tests/test_config_generator.rs
@@ -11,7 +11,7 @@ fn test_zero_with_zero_true() -> Result<(), String> {
     let mut generator = ConfigGenerator::default();
     generator.add_cnf(cnf);
     let var = (0, true); // The literal that must be true
-    let configs = generator.all_configs_given_a_var(var);
+    let configs = generator.all_configs_given_a_var(vec![var]);
     let configs_str = ConfigGeneratorUtils::to_string(&configs);
 
     assert_eq!(configs.len(), 1);
@@ -26,7 +26,7 @@ fn test_zero_with_zero_false() -> Result<(), String> {
     let mut generator = ConfigGenerator::default();
     generator.add_cnf(cnf);
     let var = (0, false); // The literal that must be true
-    let configs = generator.all_configs_given_a_var(var);
+    let configs = generator.all_configs_given_a_var(vec![var]);
     let configs_str = ConfigGeneratorUtils::to_string(&configs);
 
     assert_eq!(configs.len(), 0);
@@ -45,17 +45,17 @@ fn complex_1() -> Result<(), String> {
     let mut generator = ConfigGenerator::default();
     generator.add_cnf(cnf);
     let var = (1, true); // The literal that must be true
-    let configs = generator.all_configs_given_a_var(var);
+    let configs = generator.all_configs_given_a_var(vec![var]);
     let configs_str = ConfigGeneratorUtils::to_string(&configs);
 
     assert_eq!(configs.len(), 5);
     assert_eq!(
         configs_str,
         "(0 & 1 & 2 & 3)\n\
-         (0 & 1 & 2 & !3)\n\
-         (!0 & 1 & 2 & !3)\n\
-         (!0 & 1 & 2 & 3)\n\
-         (0 & 1 & !2 & !3)\n"
+(0 & 1 & 2 & !3)\n\
+(!0 & 1 & 2 & !3)\n\
+(!0 & 1 & 2 & 3)\n\
+(0 & 1 & !2 & !3)\n"
     );
 
     Ok(())
@@ -67,7 +67,7 @@ fn test_simple_real_case() -> Result<(), String> {
     let mut generator = ConfigGenerator::default();
     generator.add_cnf(cnf);
     let var = (0, true); // The literal that must be true
-    let configs = generator.all_configs_given_a_var(var);
+    let configs = generator.all_configs_given_a_var(vec![var]);
     let configs_str = ConfigGeneratorUtils::to_string(&configs);
 
     assert_eq!(configs.len(), 2);
@@ -75,3 +75,44 @@ fn test_simple_real_case() -> Result<(), String> {
 
     Ok(())
 }
+
+#[test]
+fn test_multiple_var1() -> Result<(), String> {
+    let cnf = vec![vec![(0, true), (1, true)], vec![(0, true), (1, true)]];
+    let mut generator = ConfigGenerator::default();
+    generator.add_cnf(cnf);
+    let vars = vec![(0, true), (1, true)]; // The literal that must be true
+    let configs = generator.all_configs_given_a_var(vars);
+    let configs_str = ConfigGeneratorUtils::to_string(&configs);
+
+    assert_eq!(configs.len(), 1);
+    assert_eq!(configs_str, "(0 & 1)\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_multiple_var2() -> Result<(), String> {
+    // (x0 | x1 | x2) & (!x0 | x1) & (x2 | !x3)
+    let cnf = vec![
+        vec![(0, true), (1, false), (2, true)],
+        vec![(0, false), (1, true)],
+        vec![(2, true), (3, false)],
+    ];
+    let mut generator = ConfigGenerator::default();
+    generator.add_cnf(cnf);
+    let vars = vec![(0, true), (1, true)]; // The literal that must be true
+    let configs = generator.all_configs_given_a_var(vars);
+    let configs_str = ConfigGeneratorUtils::to_string(&configs);
+
+    assert_eq!(configs.len(), 3);
+    assert_eq!(
+        configs_str,
+        "(0 & 1 & 2 & 3)\n\
+(0 & 1 & 2 & !3)\n\
+(0 & 1 & !2 & !3)\n"
+    );
+
+    Ok(())
+}
+


### PR DESCRIPTION
# Summary 

- Move centrality measures in a separate file
- Now `all_configs_given_a_var` accepts a `Vec` of `CnfLit`