### PR TITLE
Fix the logic of refinement process

### DIFF
--- a/rusty_ex/src/configs/centrality.rs
+++ b/rusty_ex/src/configs/centrality.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{FeatureIndex, FeaturesGraph},
-    GLOBAL_DUMMY_INDEX,
+    GLOBAL_DUMMY_INDEX, GLOBAL_NODE_INDEX,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -35,13 +35,17 @@ impl Centrality {
     /// centrality measures.
     ///
     /// NOTE: The dummy node is the node with the index GLOBAL_DUMMY_INDEX.
-    /// If `remove_dummy` is false, you have to be sure when calling
-    /// `refine` that the dummy node is not present in the refiner hashmap.
-    pub fn new(feat_graph: &FeaturesGraph, remove_dummy: bool) -> Self {
+    /// If `remove_dummy_and_global` is false, you have to be sure when calling
+    /// `refine` that the dummy node and the global node are not present in the
+    /// refiner hashmap.
+    pub fn new(feat_graph: &FeaturesGraph, remove_dummy_and_global: bool) -> Self {
         let node_indices = feat_graph.graph.node_indices();
-        let feat_graph_indices = if remove_dummy {
+        let feat_graph_indices = if remove_dummy_and_global {
             node_indices
-                .filter(|node| *node != FeatureIndex::new(GLOBAL_DUMMY_INDEX))
+                .filter(|node| {
+                    *node != FeatureIndex::new(GLOBAL_DUMMY_INDEX)
+                        && *node != FeatureIndex::new(GLOBAL_NODE_INDEX)
+                })
                 .collect::<Vec<FeatureIndex>>()
         } else {
             node_indices.collect::<Vec<FeatureIndex>>()

--- a/rusty_ex/src/configs/centrality.rs
+++ b/rusty_ex/src/configs/centrality.rs
@@ -16,7 +16,7 @@ pub enum CentralityKind {
     Eigenvector,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub struct Centrality {
     pub measures: CentralityMeasures,
     pub feat_graph_indices: Vec<FeatureIndex>,

--- a/rusty_ex/src/lib.rs
+++ b/rusty_ex/src/lib.rs
@@ -880,7 +880,7 @@ impl CollectVisitor {
     fn serialized_centrality(&self, kind: &CentralityKind) {
         match kind {
             CentralityKind::All => {
-                let measures = &self.centrality.as_ref().unwrap().measures;
+                let measures = &self.centrality.as_ref().unwrap();
                 println!(
                     "{}",
                     serde_json::to_string(measures).expect("Error: cannot serialize data")

--- a/rusty_ex/src/lib.rs
+++ b/rusty_ex/src/lib.rs
@@ -292,7 +292,7 @@ impl rustc_driver::Callbacks for PrintAstCallbacks {
 
                 let refiner_hm = collector
                     .artifacts_tree
-                    .refiner_hash_map(&collector.features_graph);
+                    .refiner_hash_map(&collector.features_graph, true);
                 let centrality = Centrality::new(&collector.features_graph, true);
                 let refined = centrality.refine(refiner_hm);
                 collector.centrality.replace(refined);

--- a/rusty_ex/src/types.rs
+++ b/rusty_ex/src/types.rs
@@ -522,7 +522,8 @@ impl<Key: ArtifactKey> ArtifactsTree<Key> {
             match complex_index {
                 ComplexFeature::None => panic!("ComplexFeature::None not expected"),
                 ComplexFeature::Simple(index) => {
-                    hm.insert(index, weight);
+                    // Add the weight to the feature index
+                    *hm.entry(index).or_insert(0.0) += weight;
                 }
                 ComplexFeature::All(complex_indexes) => {
                     // In `All` case, the weight is divided by the number of features

--- a/rusty_ex/tests/snippets/centrality/one_important_feature.rs
+++ b/rusty_ex/tests/snippets/centrality/one_important_feature.rs
@@ -1,7 +1,7 @@
 fn bar() {}
 fn baz(_: &str) {}
 
-#[cfg(all(feature = "f1", feature = "f2"))]
+#[cfg(feature = "f1")]
 fn foo() {
     #[cfg(any(feature = "f2", feature = "f3", all(feature = "f2", feature = "f3")))]
     baz("hello");
@@ -13,6 +13,4 @@ fn foo() {
 #[cfg(any(feature = "f1", feature = "f2"))]
 fn foo() {}
 
-fn main() {
-    foo()
-}
+fn main() {}

--- a/rusty_ex/tests/snippets/centrality/one_important_nested_feature.rs
+++ b/rusty_ex/tests/snippets/centrality/one_important_nested_feature.rs
@@ -1,0 +1,22 @@
+fn bar() {
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+    let _ = 1;
+}
+
+#[cfg(feature = "f1")]
+fn foo() {
+    #[cfg(feature = "f2")]
+    bar();
+}
+
+fn main() {}

--- a/rusty_ex/tests/test_centrality_measures.rs
+++ b/rusty_ex/tests/test_centrality_measures.rs
@@ -18,6 +18,7 @@ macro_rules! assert_almost_equal {
 
 macro_rules! assert_almost_equal_iter {
     ($expected:expr, $computed:expr, $tolerance:expr) => {
+        assert_eq!($expected.len(), $computed.len());
         for (expected, computed) in $expected.iter().zip($computed.iter()) {
             assert_almost_equal!(expected, computed, $tolerance);
         }
@@ -26,9 +27,21 @@ macro_rules! assert_almost_equal_iter {
 
 macro_rules! assert_almost_equal_option_iter {
     ($expected:expr, $computed:expr, $tolerance:expr) => {
+        assert_eq!($expected.len(), $computed.len());
         for (expected, computed) in $expected.iter().zip($computed.iter()) {
             assert_almost_equal!(expected.unwrap(), computed.unwrap(), $tolerance);
         }
+    };
+}
+
+macro_rules! assert_greatest_index {
+    ($computed:expr, $index:expr) => {
+        let max = $computed
+            .iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap();
+        let index = $computed.iter().position(|&x| x == *max).unwrap();
+        assert_eq!(index, $index);
     };
 }
 
@@ -46,9 +59,9 @@ fn test_no_centrality() -> Result<(), String> {
     let closeness = centrality.closeness();
     let eigenvector = centrality.eigenvector().unwrap();
 
-    assert_eq!(*katz, vec![0.0, 0.0, 0.0]);
-    assert_eq!(*closeness, vec![Some(0.0), Some(0.0), Some(0.0)]);
-    assert_eq!(*eigenvector, vec![0.0, 0.0, 0.0]);
+    assert_eq!(*katz, vec![0.0, 0.0]);
+    assert_eq!(*closeness, vec![Some(0.0), Some(0.0)]);
+    assert_eq!(*eigenvector, vec![0.0, 0.0]);
 
     Ok(())
 }
@@ -61,19 +74,59 @@ fn test_nested_features() -> Result<(), String> {
     let closeness = centrality.closeness();
     let eigenvector = centrality.eigenvector().unwrap();
 
-    let katz_out = vec![0.4416, 0.0785, 0.3360, 0.2240, 0.0507];
-    let closeness_out = vec![
-        Some(0.625),
-        Some(0.1048),
-        Some(0.5769),
-        Some(0.2884),
-        Some(0.0591),
-    ];
-    let eigenvector_out = vec![0.6203, 0.0601, 0.3546, 0.2364, 0.0162];
+    let katz_out = vec![0.14722, 0.34022, 0.3236, 0.1078];
+    let closeness_out = vec![Some(0.2083), Some(0.4545), Some(0.5555), Some(0.1388)];
+    let eigenvector_out = vec![0.2067, 0.2606, 0.3415, 0.1138];
 
     assert_almost_equal_iter!(*katz_out, katz, 1e-4);
     assert_almost_equal_option_iter!(*closeness_out, closeness, 1e-4);
     assert_almost_equal_iter!(*eigenvector_out, eigenvector, 1e-4);
+
+    Ok(())
+}
+
+#[test]
+fn test_one_important_feature() -> Result<(), String> {
+    let centrality = get_centrality_measures("one_important_feature.rs")?;
+
+    let katz = centrality.katz().unwrap();
+    let closeness = centrality.closeness();
+    let eigenvector = centrality.eigenvector().unwrap();
+
+    let katz_out = vec![0.4620, 0.3708, 0.5064, 0.1205];
+    let closeness_out = vec![Some(0.625), Some(0.4545), Some(0.8333), Some(0.1190)];
+    let eigenvector_out = vec![0.6845, 0.3466, 0.5617, 0.0595];
+
+    assert_almost_equal_iter!(*katz_out, katz, 1e-4);
+    assert_almost_equal_option_iter!(*closeness_out, closeness, 1e-4);
+    assert_almost_equal_iter!(*eigenvector_out, eigenvector, 1e-4);
+
+    assert_greatest_index!(katz, 2);
+    assert_greatest_index!(closeness, 2);
+    assert_greatest_index!(eigenvector, 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_one_important_nested_feature() -> Result<(), String> {
+    let centrality = get_centrality_measures("one_important_nested_feature.rs")?;
+
+    let katz = centrality.katz().unwrap();
+    let closeness = centrality.closeness();
+    let eigenvector = centrality.eigenvector().unwrap();
+
+    let katz_out = vec![0.4909, 0.4865];
+    let closeness_out = vec![Some(0.6), Some(0.5)];
+    let eigenvector_out = vec![0.5357, 0.4358];
+
+    assert_almost_equal_iter!(*katz_out, katz, 1e-4);
+    assert_almost_equal_option_iter!(*closeness, closeness_out, 1e-4);
+    assert_almost_equal_iter!(*eigenvector_out, eigenvector, 1e-4);
+
+    assert_greatest_index!(katz, 0);
+    assert_greatest_index!(closeness, 0);
+    assert_greatest_index!(eigenvector, 0);
 
     Ok(())
 }

--- a/rusty_ex/tests/test_centrality_measures.rs
+++ b/rusty_ex/tests/test_centrality_measures.rs
@@ -3,7 +3,7 @@
 mod utils;
 
 use pretty_assertions::assert_eq;
-use rusty_ex::configs::centrality::CentralityMeasures;
+use rusty_ex::configs::centrality::{Centrality, CentralityMeasures};
 use utils::run_with_cargo_bin_and_snippet;
 
 const CENTRALITY_FOLDER: &str = "tests/snippets/centrality";
@@ -32,23 +32,23 @@ macro_rules! assert_almost_equal_option_iter {
     };
 }
 
-fn get_centrality_measures(file: &str) -> Result<CentralityMeasures, String> {
+fn get_centrality_measures(file: &str) -> Result<Centrality, String> {
     let snippet = &std::fs::read_to_string(format!("{CENTRALITY_FOLDER}/{file}")).unwrap();
     let (output, _) = run_with_cargo_bin_and_snippet(snippet, &["--serialized-centrality", "all"])?;
-    let deserialized_centrality: CentralityMeasures = serde_json::from_str(&output).unwrap();
+    let deserialized_centrality: Centrality = serde_json::from_str(&output).unwrap();
     Ok(deserialized_centrality)
 }
 
 #[test]
 fn test_no_centrality() -> Result<(), String> {
-    let measures = get_centrality_measures("no_centrality.rs")?;
-    let katz = measures.katz.unwrap();
-    let closeness = measures.closeness;
-    let eigenvector = measures.eigenvector.unwrap();
+    let centrality = get_centrality_measures("no_centrality.rs")?;
+    let katz = centrality.katz().unwrap();
+    let closeness = centrality.closeness();
+    let eigenvector = centrality.eigenvector().unwrap();
 
-    assert_eq!(katz, vec![0.0, 0.0, 0.0]);
-    assert_eq!(closeness, vec![Some(0.0), Some(0.0), Some(0.0)]);
-    assert_eq!(eigenvector, vec![0.0, 0.0, 0.0]);
+    assert_eq!(*katz, vec![0.0, 0.0, 0.0]);
+    assert_eq!(*closeness, vec![Some(0.0), Some(0.0), Some(0.0)]);
+    assert_eq!(*eigenvector, vec![0.0, 0.0, 0.0]);
 
     Ok(())
 }

--- a/rusty_ex/tests/test_centrality_measures.rs
+++ b/rusty_ex/tests/test_centrality_measures.rs
@@ -3,7 +3,7 @@
 mod utils;
 
 use pretty_assertions::assert_eq;
-use rusty_ex::configs::centrality::{Centrality, CentralityMeasures};
+use rusty_ex::configs::centrality::Centrality;
 use utils::run_with_cargo_bin_and_snippet;
 
 const CENTRALITY_FOLDER: &str = "tests/snippets/centrality";
@@ -55,25 +55,25 @@ fn test_no_centrality() -> Result<(), String> {
 
 #[test]
 fn test_nested_features() -> Result<(), String> {
-    let measures = get_centrality_measures("nested_features.rs")?;
+    let centrality = get_centrality_measures("nested_features.rs")?;
 
-    let katz = measures.katz.unwrap();
-    let closeness = measures.closeness;
-    let eigenvector = measures.eigenvector.unwrap();
+    let katz = centrality.katz().unwrap();
+    let closeness = centrality.closeness();
+    let eigenvector = centrality.eigenvector().unwrap();
 
-    let katz_out = vec![0.4416, 0.0, 0.0, 0.0746, 0.0507];
+    let katz_out = vec![0.4416, 0.0785, 0.3360, 0.2240, 0.0507];
     let closeness_out = vec![
         Some(0.625),
-        Some(0.0),
-        Some(0.0),
-        Some(0.0961),
+        Some(0.1048),
+        Some(0.5769),
+        Some(0.2884),
         Some(0.0591),
     ];
-    let eigenvector_out = vec![0.6203, 0.0, 0.0, 0.0788, 0.0162];
+    let eigenvector_out = vec![0.6203, 0.0601, 0.3546, 0.2364, 0.0162];
 
-    assert_almost_equal_iter!(katz_out, katz, 1e-4);
-    assert_almost_equal_option_iter!(closeness_out, closeness, 1e-4);
-    assert_almost_equal_iter!(eigenvector_out, eigenvector, 1e-4);
+    assert_almost_equal_iter!(*katz_out, katz, 1e-4);
+    assert_almost_equal_option_iter!(*closeness_out, closeness, 1e-4);
+    assert_almost_equal_iter!(*eigenvector_out, eigenvector, 1e-4);
 
     Ok(())
 }


### PR DESCRIPTION
# Summary

- Ingore `__GLOBAL__` node in the `FeatureGraph` and `ArtifactTree` (when reasoning about centralities)

- New logic for refinement process

- New tests for centrality measures